### PR TITLE
clients: logger

### DIFF
--- a/packages/fossilizer-client/src/httpClient.spec.ts
+++ b/packages/fossilizer-client/src/httpClient.spec.ts
@@ -158,6 +158,19 @@ describe('fossilizer http client', () => {
     });
   });
 
+  describe('timeout', () => {
+    it('rejects negative values', () => {
+      const c = new FossilizerHttpClient('http://localhost');
+      expect(() => c.setRequestTimeout(-1)).toThrow();
+    });
+
+    it('sets request timeout', () => {
+      const c = new FossilizerHttpClient('http://localhost');
+      c.setRequestTimeout(42);
+      expect((c as any).reqConfig.timeout).toEqual(42);
+    });
+  });
+
   describe('info', () => {
     it('throws in case of network error', async () => {
       axiosMock = jest.spyOn(axios, 'get');

--- a/packages/fossilizer-client/src/httpClient.ts
+++ b/packages/fossilizer-client/src/httpClient.ts
@@ -71,6 +71,18 @@ export class FossilizerHttpClient implements IFossilizerClient {
     }
   }
 
+  /**
+   * Set the request timeout value.
+   * @param timeoutMS timeout in milliseconds.
+   */
+  public setRequestTimeout(timeoutMS: number) {
+    if (timeoutMS <= 0) {
+      throw new Error('Timeout should be a strictly positive value');
+    }
+
+    this.reqConfig.timeout = timeoutMS;
+  }
+
   public async info(): Promise<any> {
     const response = await axios.get(this.fossilizerUrl, this.reqConfig);
     this.handleHttpErr(response);

--- a/packages/fossilizer-client/src/httpClient.ts
+++ b/packages/fossilizer-client/src/httpClient.ts
@@ -18,6 +18,7 @@ import axios, { AxiosRequestConfig } from 'axios';
 import WebSocket from 'isomorphic-ws';
 import { IFossilizerClient } from './client';
 import { DID_FOSSILIZE_LINK_EVENT, FossilizedEvent } from './events';
+import { ILogger } from './logger';
 
 /**
  * FossilizerHttpClient provides access to the Chainscript fossilizer API
@@ -27,8 +28,10 @@ import { DID_FOSSILIZE_LINK_EVENT, FossilizedEvent } from './events';
  */
 export class FossilizerHttpClient implements IFossilizerClient {
   private fossilizerUrl: string;
-  private reqConfig: AxiosRequestConfig;
   private socket?: WebSocket;
+
+  private reqConfig: AxiosRequestConfig;
+  private logger?: ILogger;
 
   /**
    * Create an http client to interact with a fossilizer.
@@ -38,14 +41,21 @@ export class FossilizerHttpClient implements IFossilizerClient {
    * to be notified when your data has been successfully fossilized.
    * @param url of the fossilizer API.
    * @param eventHandler (optional) event handler for fossilizer notifications.
+   * @param logger (optional) logger for internal events. If you don't set a
+   * logger events will be dropped.
    */
-  constructor(url: string, eventHandler?: (e: FossilizedEvent) => void) {
+  constructor(
+    url: string,
+    eventHandler?: (e: FossilizedEvent) => void,
+    logger?: ILogger
+  ) {
     if (url.endsWith('/')) {
       this.fossilizerUrl = url.substring(0, url.length - 1);
     } else {
       this.fossilizerUrl = url;
     }
 
+    this.logger = logger;
     this.reqConfig = {
       timeout: 10000,
       // We want to handle http errors ourselves.
@@ -55,16 +65,32 @@ export class FossilizerHttpClient implements IFossilizerClient {
     if (eventHandler) {
       this.socket = new WebSocket(this.fossilizerUrl + '/websocket');
       this.socket.on('open', () => {
+        if (this.logger) {
+          this.logger.info({
+            component: 'fossilizerClient',
+            name: 'socketOpen'
+          });
+        }
+
         (this.socket as WebSocket).on('message', (jsonPayload: string) => {
+          if (this.logger) {
+            this.logger.info({
+              component: 'fossilizerClient',
+              message: jsonPayload,
+              name: 'socketMessage'
+            });
+          }
+
           try {
             const message = JSON.parse(jsonPayload);
             if (message.type === DID_FOSSILIZE_LINK_EVENT) {
               const event = new FossilizedEvent(message.data);
               eventHandler(event);
             }
-          } catch {
-            // We currently ignore event errors.
-            // We will log them once we have a logging infrastructure.
+          } catch (err) {
+            if (this.logger) {
+              this.logger.error(err);
+            }
           }
         });
       });

--- a/packages/fossilizer-client/src/index.ts
+++ b/packages/fossilizer-client/src/index.ts
@@ -15,5 +15,6 @@
 */
 
 export { IFossilizerClient } from './client';
+export { ILogger } from './logger';
 export { FossilizedEvent } from './events';
 export { FossilizerHttpClient } from './httpClient';

--- a/packages/fossilizer-client/src/logger.ts
+++ b/packages/fossilizer-client/src/logger.ts
@@ -1,0 +1,43 @@
+/*
+  Copyright 2018 Stratumn SAS. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/**
+ * Components in this package use this interface for logging.
+ * You should provide your own implementation of this interface that plugs into
+ * your monitoring system.
+ * This way you'll get all the events raised from this package's components.
+ */
+export interface ILogger {
+  /**
+   * Log information (non-error).
+   * This can become noisy so it should usually be disabled in production or
+   * randomly sampled.
+   * @param event details.
+   */
+  info(event: any): void;
+
+  /**
+   * Log a warning (non-critical error).
+   * @param event details.
+   */
+  warn(event: any): void;
+
+  /**
+   * Log an error.
+   * @param event details.
+   */
+  error(event: any): void;
+}

--- a/packages/store-client/src/httpClient.spec.ts
+++ b/packages/store-client/src/httpClient.spec.ts
@@ -132,6 +132,19 @@ describe('store http client', () => {
     });
   });
 
+  describe('timeout', () => {
+    it('rejects negative values', () => {
+      const c = new StoreHttpClient('http://localhost');
+      expect(() => c.setRequestTimeout(-1)).toThrow();
+    });
+
+    it('sets request timeout', () => {
+      const c = new StoreHttpClient('http://localhost');
+      c.setRequestTimeout(42);
+      expect((c as any).reqConfig.timeout).toEqual(42);
+    });
+  });
+
   describe('info', () => {
     it('throws in case of network error', async () => {
       axiosMock = jest.spyOn(axios, 'get');

--- a/packages/store-client/src/httpClient.ts
+++ b/packages/store-client/src/httpClient.ts
@@ -78,6 +78,18 @@ export class StoreHttpClient implements IStoreClient {
     }
   }
 
+  /**
+   * Set the request timeout value.
+   * @param timeoutMS timeout in milliseconds.
+   */
+  public setRequestTimeout(timeoutMS: number) {
+    if (timeoutMS <= 0) {
+      throw new Error('Timeout should be a strictly positive value');
+    }
+
+    this.reqConfig.timeout = timeoutMS;
+  }
+
   public async info(): Promise<any> {
     const response = await axios.get(this.storeUrl, this.reqConfig);
     this.handleHttpErr(response);

--- a/packages/store-client/src/httpClient.ts
+++ b/packages/store-client/src/httpClient.ts
@@ -24,6 +24,7 @@ import axios, { AxiosRequestConfig } from 'axios';
 import WebSocket from 'isomorphic-ws';
 import { IStoreClient } from './client';
 import { StoreEvent } from './events';
+import { ILogger } from './logger';
 import { Pagination } from './pagination';
 import { Segments } from './segments';
 import { SegmentsFilter } from './segmentsFilter';
@@ -36,8 +37,10 @@ import { SegmentsFilter } from './segmentsFilter';
  */
 export class StoreHttpClient implements IStoreClient {
   private storeUrl: string;
-  private reqConfig: AxiosRequestConfig;
   private socket?: WebSocket;
+
+  private reqConfig: AxiosRequestConfig;
+  private logger?: ILogger;
 
   /**
    * Create an http client to interact with a Chainscript Store.
@@ -47,14 +50,21 @@ export class StoreHttpClient implements IStoreClient {
    * @param eventHandler (optional) event handler for store notifications.
    * The store will send notifications when links are created and new evidence
    * is added.
+   * @param logger (optional) logger for internal events. If you don't set a
+   * logger events will be dropped.
    */
-  constructor(url: string, eventHandler?: (e: StoreEvent) => void) {
+  constructor(
+    url: string,
+    eventHandler?: (e: StoreEvent) => void,
+    logger?: ILogger
+  ) {
     if (url.endsWith('/')) {
       this.storeUrl = url.substring(0, url.length - 1);
     } else {
       this.storeUrl = url;
     }
 
+    this.logger = logger;
     this.reqConfig = {
       timeout: 10000,
       // We want to handle http errors ourselves.
@@ -64,14 +74,27 @@ export class StoreHttpClient implements IStoreClient {
     if (eventHandler) {
       this.socket = new WebSocket(this.storeUrl + '/websocket');
       this.socket.on('open', () => {
+        if (this.logger) {
+          this.logger.info({ component: 'storeClient', name: 'socketOpen' });
+        }
+
         (this.socket as WebSocket).on('message', (jsonPayload: string) => {
+          if (this.logger) {
+            this.logger.info({
+              component: 'storeClient',
+              message: jsonPayload,
+              name: 'socketMessage'
+            });
+          }
+
           try {
             const message = JSON.parse(jsonPayload);
             const event = new StoreEvent(message);
             eventHandler(event);
-          } catch {
-            // We currently ignore event errors.
-            // We will log them once we have a logging infrastructure.
+          } catch (err) {
+            if (this.logger) {
+              this.logger.error(err);
+            }
           }
         });
       });

--- a/packages/store-client/src/index.ts
+++ b/packages/store-client/src/index.ts
@@ -14,6 +14,7 @@
   limitations under the License.
 */
 
+export { ILogger } from './logger';
 export { IStoreClient } from './client';
 export { Pagination } from './pagination';
 export { Segments } from './segments';

--- a/packages/store-client/src/logger.ts
+++ b/packages/store-client/src/logger.ts
@@ -1,0 +1,43 @@
+/*
+  Copyright 2018 Stratumn SAS. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/**
+ * Components in this package use this interface for logging.
+ * You should provide your own implementation of this interface that plugs into
+ * your monitoring system.
+ * This way you'll get all the events raised from this package's components.
+ */
+export interface ILogger {
+  /**
+   * Log information (non-error).
+   * This can become noisy so it should usually be disabled in production or
+   * randomly sampled.
+   * @param event details.
+   */
+  info(event: any): void;
+
+  /**
+   * Log a warning (non-critical error).
+   * @param event details.
+   */
+  warn(event: any): void;
+
+  /**
+   * Log an error.
+   * @param event details.
+   */
+  error(event: any): void;
+}


### PR DESCRIPTION
Let users set custom timeout values.
Add a logger interface that users can provide to get internal events.
There is a lot of duplication between the two clients (store and fossilizer) but I haven't found yet the right abstraction to extract (I really want to avoid a 'utils' package) so that will be refactored later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-core/12)
<!-- Reviewable:end -->
