### PR TITLE
clients: returned structured http errors

### DIFF
--- a/packages/fossilizer-client/src/httpClient.spec.ts
+++ b/packages/fossilizer-client/src/httpClient.spec.ts
@@ -234,6 +234,19 @@ describe('fossilizer http client', () => {
       expect(err).toEqual(new Error('HTTP 400: Bad Request'));
     });
 
+    it('throws server error if provided', async () => {
+      axiosMock = jest.spyOn(axios, 'post');
+      axiosMock.mockResolvedValue({
+        data: { error: { message: 'Missing data' } },
+        status: 400,
+        statusText: 'Bad Request'
+      });
+
+      const [err] = await to(client.fossilize('', 'missing data'));
+      expect(axiosMock).toHaveBeenCalled();
+      expect(err).toEqual({ message: 'Missing data' });
+    });
+
     it('fossilizes data', async () => {
       axiosMock = jest.spyOn(axios, 'post');
       axiosMock.mockResolvedValue({

--- a/packages/fossilizer-client/src/httpClient.ts
+++ b/packages/fossilizer-client/src/httpClient.ts
@@ -136,6 +136,14 @@ export class FossilizerHttpClient implements IFossilizerClient {
    */
   private handleHttpErr(response: any) {
     if (response.status !== 200) {
+      if (this.logger) {
+        this.logger.error(response);
+      }
+
+      if (response.data.error) {
+        throw response.data.error;
+      }
+
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
   }

--- a/packages/fossilizer-client/src/httpClient.ts
+++ b/packages/fossilizer-client/src/httpClient.ts
@@ -140,7 +140,7 @@ export class FossilizerHttpClient implements IFossilizerClient {
         this.logger.error(response);
       }
 
-      if (response.data.error) {
+      if (response.data && response.data.error) {
         throw response.data.error;
       }
 

--- a/packages/store-client/src/httpClient.spec.ts
+++ b/packages/store-client/src/httpClient.spec.ts
@@ -164,6 +164,19 @@ describe('store http client', () => {
       expect(err).toEqual(new Error('HTTP 404: Not Found'));
     });
 
+    it('throws server error if provided', async () => {
+      axiosMock = jest.spyOn(axios, 'get');
+      axiosMock.mockResolvedValue({
+        data: { error: { message: 'Too bad' } },
+        status: 400,
+        statusText: 'Bad Request'
+      });
+
+      const [err] = await to(client.info());
+      expect(axiosMock).toHaveBeenCalled();
+      expect(err).toEqual({ message: 'Too bad' });
+    });
+
     it('returns store info', async () => {
       const info = {
         description: 'PostgreSQL Chainscript Storage',

--- a/packages/store-client/src/httpClient.ts
+++ b/packages/store-client/src/httpClient.ts
@@ -219,6 +219,14 @@ export class StoreHttpClient implements IStoreClient {
    */
   private handleHttpErr(response: any) {
     if (response.status !== 200) {
+      if (this.logger) {
+        this.logger.error(response);
+      }
+
+      if (response.data.error) {
+        throw response.data.error;
+      }
+
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
   }

--- a/packages/store-client/src/httpClient.ts
+++ b/packages/store-client/src/httpClient.ts
@@ -223,7 +223,7 @@ export class StoreHttpClient implements IStoreClient {
         this.logger.error(response);
       }
 
-      if (response.data.error) {
+      if (response.data && response.data.error) {
         throw response.data.error;
       }
 


### PR DESCRIPTION
The store now returns properly structured json errors, so let's leverage them in Javascript by throwing them instead of swallowing them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-core/31)
<!-- Reviewable:end -->
