### PR TITLE
clients: fix websocket

### DIFF
--- a/packages/fossilizer-client/package.json
+++ b/packages/fossilizer-client/package.json
@@ -55,7 +55,7 @@
     "axios": "^0.18.0",
     "buffer": "^5.2.1",
     "isomorphic-ws": "^4.0.1",
-    "ws": "^6.1.0"
+    "ws": "^6.1.2"
   },
   "devDependencies": {
     "@types/ws": "^6.0.1",

--- a/packages/fossilizer-client/yarn.lock
+++ b/packages/fossilizer-client/yarn.lock
@@ -3779,10 +3779,10 @@ ws@^5.2.0:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.0.tgz#119a9dbf92c54e190ec18d10e871d55c95cf9373"
-  integrity sha512-H3dGVdGvW2H8bnYpIDc3u3LH8Wue3Qh+Zto6aXXFzvESkTVT6rAfKR6tR/+coaUvxs8yHtmNV0uioBF62ZGSTg==
+ws@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.2.tgz#3cc7462e98792f0ac679424148903ded3b9c3ad8"
+  integrity sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==
   dependencies:
     async-limiter "~1.0.0"
 

--- a/packages/store-client/package.json
+++ b/packages/store-client/package.json
@@ -52,7 +52,8 @@
   "dependencies": {
     "@stratumn/js-chainscript": "^1.0.3",
     "axios": "^0.18.0",
-    "isomorphic-ws": "^4.0.1"
+    "isomorphic-ws": "^4.0.1",
+    "ws": "^6.1.2"
   },
   "devDependencies": {
     "@types/jest": "^23.3.7",

--- a/packages/store-client/yarn.lock
+++ b/packages/store-client/yarn.lock
@@ -3789,6 +3789,13 @@ ws@^5.2.0:
   dependencies:
     async-limiter "~1.0.0"
 
+ws@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.2.tgz#3cc7462e98792f0ac679424148903ded3b9c3ad8"
+  integrity sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==
+  dependencies:
+    async-limiter "~1.0.0"
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"


### PR DESCRIPTION
The `ws` library is a peer dependency that should be met in our package, so adding ws explicitly.
There was an issue with the type bindings and in the browser the socket.on() method doesn't exist, so replacing it with the dedicated `socket.onopen/onclose/onmessage` methods.
Adding a bit of logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-core/40)
<!-- Reviewable:end -->
