### PR TITLE
map-explorer: display internal references

### DIFF
--- a/packages/react-map-explorer/src/mapExplorerDisplay.spec.ts
+++ b/packages/react-map-explorer/src/mapExplorerDisplay.spec.ts
@@ -45,10 +45,14 @@ describe('map explorer display', () => {
       .build()
       .segmentify();
 
-    const layout = prepareSegments([child1, grandchild, root, child2]);
+    const layout = prepareSegments(
+      [child1, grandchild, root, child2],
+      'p',
+      'm'
+    );
     expect(layout.id).toEqual(hashToString(root.linkHash()));
+    expect(layout.data.external).toBeFalsy();
     expect(layout.data.step).toEqual('init');
-    expect(layout.data.isRef).toBeFalsy();
     expect(layout.height).toEqual(2);
     expect(layout.children).toHaveLength(2);
 
@@ -56,6 +60,7 @@ describe('map explorer display', () => {
       c => c.id === hashToString(child2.linkHash())
     );
     expect(c2.parent.id).toEqual(hashToString(root.linkHash()));
+    expect(c2.data.external).toBeFalsy();
     expect(c2.data.step).toEqual('split');
     expect(c2.depth).toEqual(1);
     expect(c2.height).toEqual(1);
@@ -76,18 +81,67 @@ describe('map explorer display', () => {
 
     const child = new LinkBuilder('p', 'm')
       .withParent(root.linkHash())
+      .withRefs([{ linkHash: ref.linkHash(), process: 'pp' }])
       .withStep('destroy')
       .build()
       .segmentify();
 
-    const layout = prepareSegments([ref, child, root]);
+    const layout = prepareSegments([ref, child, root], 'p', 'm');
     expect(layout.id).toEqual(hashToString(root.linkHash()));
+    expect(layout.data.external).toBeFalsy();
     expect(layout.data.step).toEqual('init');
-    expect(layout.height).toEqual(1);
+    expect(layout.height).toEqual(2);
     expect(layout.children).toHaveLength(2);
 
+    // Root node should show the reference as a child.
     const r = layout.children.find(c => c.id === hashToString(ref.linkHash()));
     expect(r.parent.id).toEqual(hashToString(root.linkHash()));
-    expect(r.data.isRef).toBeTruthy();
+    expect(r.data.external).toBeTruthy();
+
+    // The child should also show the reference as its own child.
+    const c1 = layout.children.find(
+      c => c.id === hashToString(child.linkHash())
+    );
+    expect(c1.data.external).toBeFalsy();
+    expect(c1.children).toHaveLength(1);
+
+    const r2 = c1.children[0];
+    expect(r2.id).toEqual(hashToString(ref.linkHash()));
+    expect(r2.data.external).toBeTruthy();
+  });
+
+  it('lays out tree with internal references', () => {
+    const root = new LinkBuilder('p', 'm')
+      .withStep('init')
+      .build()
+      .segmentify();
+
+    const c1 = new LinkBuilder('p', 'm')
+      .withParent(root.linkHash())
+      .withStep('destroy')
+      .build()
+      .segmentify();
+    const ch1 = hashToString(c1.linkHash());
+
+    const c2 = new LinkBuilder('p', 'm')
+      .withParent(root.linkHash())
+      .withRefs([{ linkHash: c1.linkHash(), process: 'p' }])
+      .withStep('repair')
+      .build()
+      .segmentify();
+
+    const layout = prepareSegments([c2, c1, root], 'p', 'm');
+    expect(layout.children).toHaveLength(2);
+
+    for (const c of layout.children) {
+      expect(c.data.external).toBeFalsy();
+      expect(c.children).toBeUndefined();
+
+      if (c.id === ch1) {
+        expect(c.data.refs).toHaveLength(0);
+      } else {
+        expect(c.data.refs).toEqual([ch1]);
+      }
+    }
   });
 });

--- a/packages/react-map-explorer/src/mapExplorerDisplay.ts
+++ b/packages/react-map-explorer/src/mapExplorerDisplay.ts
@@ -14,8 +14,13 @@
   limitations under the License.
 */
 
-import { LinkReference, Segment } from '@stratumn/js-chainscript';
-import { HierarchyPointNode, stratify, tree } from 'd3-hierarchy';
+import { Segment } from '@stratumn/js-chainscript';
+import {
+  HierarchyPointLink,
+  HierarchyPointNode,
+  stratify,
+  tree
+} from 'd3-hierarchy';
 import { select } from 'd3-selection';
 import { hashToString } from './hash';
 
@@ -31,66 +36,70 @@ interface IMapProps {
 }
 
 interface ISegmentData {
-  isRef: boolean;
+  external: boolean;
   linkHash: string;
   parentHash: string;
+  refs: string[]; // internal references (same map)
   step: string;
 }
 
 /**
  * Transform a segment array to a hierarchical structure suitable for D3
  * tree rendering.
- * Note: if a segment references another segment in the same map, we don't
- * have a tree structure anymore (because that referenced segment will have
- * two parents). This case isn't handled right now and the universe will
- * collapse if your map has such a layout.
- * We should update from d3-hierarchy to d3-dag to handle such cases (when
- * the d3-dag library is ready) or use dagre-d3.
- * We should also load the map iteratively to provide a more responsive user
- * experience.
  * @param segments contained in the map.
+ * @param process of the displayed map.
+ * @param mapId id of the displayed map.
  */
 export const prepareSegments = (
-  segments: Segment[]
+  segments: Segment[],
+  process: string,
+  mapId: string
 ): HierarchyPointNode<ISegmentData> => {
-  // We need a first pass to detect all references and connect them to the
-  // segment that references them.
-  const refs: ISegmentData[] = [];
+  const data: ISegmentData[] = [];
   for (const s of segments) {
-    const currentRefs = s
-      .link()
-      .refs()
-      .map((r: LinkReference) => ({
-        isRef: true,
-        linkHash: hashToString(r.linkHash),
-        parentHash: hashToString(s.linkHash()),
-        step: ''
-      }));
-    refs.push(...currentRefs);
-  }
-
-  // Then we convert segments to segment data and make sure references point to
-  // the segment that references them (and not their own parent segment).
-  const data = segments.map((s: Segment) => {
-    const asRef = refs.find(
-      (r: ISegmentData) => r.linkHash === hashToString(s.linkHash())
-    );
-
-    // If the segment is referenced, we display it as an external ref.
-    if (asRef) {
-      return asRef;
+    // If the link is an external reference, we will add it when we add the
+    // segment that references it.
+    if (s.link().process().name !== process || s.link().mapId() !== mapId) {
+      continue;
     }
 
-    // Otherwise it's a normal segment.
-    return {
-      isRef: false,
+    // Prepare the segment to display.
+    const sData: ISegmentData = {
+      external: false,
       linkHash: hashToString(s.linkHash()),
       parentHash: s.link().prevLinkHash()
         ? hashToString(s.link().prevLinkHash())
         : '',
+      refs: [],
       step: s.link().step()
     };
-  });
+
+    // Add the references.
+    for (const r of s.link().refs()) {
+      const rid = hashToString(r.linkHash);
+      const rs = findSegment(rid, segments);
+      if (rs.link().process().name === process && rs.link().mapId() === mapId) {
+        // If the referenced link is inside the map, it will be displayed as a
+        // normal map segment. We'll add an additional connection to it in a
+        // second display pass.
+        // Otherwise we'd need to handle multiple parents which d3-hierarchy
+        // doesn't do.
+        sData.refs.push(rid);
+      } else {
+        // Otherwise we display the external reference as a child of the
+        // current segment.
+        data.push({
+          external: true,
+          linkHash: rid,
+          parentHash: sData.linkHash,
+          refs: [],
+          step: rs.link().step()
+        });
+      }
+    }
+
+    data.push(sData);
+  }
 
   const root = stratify<ISegmentData>()
     .id(d => d.linkHash)
@@ -145,7 +154,7 @@ export const displayMap = (
 ) => {
   reset(node);
 
-  const displayTree = prepareSegments(segments);
+  const displayTree = prepareSegments(segments, props.process, props.mapId);
 
   // Create containers for nodes and links.
   const innerG = select(node)
@@ -169,7 +178,7 @@ export const displayMap = (
     .attr('y', d => d.x)
     .attr('width', segmentSize)
     .attr('height', segmentSize)
-    .style('fill', d => (d.data.isRef ? 'red' : 'steelblue'))
+    .style('fill', d => (d.data.external ? 'red' : 'steelblue'))
     .on('click', d => {
       if (props.onSegmentSelected) {
         const selected = findSegment(d.id as string, segments);
@@ -208,4 +217,40 @@ export const displayMap = (
     .attr('y2', d => d.target.x + segmentSize / 2)
     .style('stroke', '#ccc')
     .style('stroke-width', '1px');
+
+  // Display connections to in-map references (tricky edge case that we handle
+  // separately).
+  // To handle this case properly we would need to migrate from d3-hierarchy to
+  // a DAG display.
+  const internalRefs: Array<HierarchyPointLink<ISegmentData>> = [];
+  for (const s of displayTree.descendants()) {
+    if (!s.data.refs) {
+      continue;
+    }
+
+    for (const r of s.data.refs) {
+      const rp = displayTree.descendants().find(d => d.id === r);
+      if (rp) {
+        internalRefs.push({
+          source: s,
+          target: rp
+        });
+      }
+    }
+  }
+
+  select(node)
+    .select('g.links')
+    .selectAll('line.links')
+    .data(internalRefs)
+    .enter()
+    .append('line')
+    .classed('link', true)
+    .attr('x1', d => d.source.y + segmentSize / 2)
+    .attr('y1', d => d.source.x + segmentSize / 2)
+    .attr('x2', d => d.target.y + segmentSize / 2)
+    .attr('y2', d => d.target.x + segmentSize / 2)
+    .style('stroke', '#ccc')
+    .style('stroke-width', '1px')
+    .style('stroke-dasharray', '2');
 };

--- a/packages/react-map-explorer/src/mapLoader.spec.ts
+++ b/packages/react-map-explorer/src/mapLoader.spec.ts
@@ -98,6 +98,8 @@ describe('store map loader', () => {
 
     expect(mock.getSegment).toHaveBeenCalled();
     expect(mock.getSegment).toHaveBeenCalledWith(hashToString(Ref.linkHash()));
+    // The reference should only appear once even though it's referenced by two
+    // distinct segments.
     expect(seg).toEqual([...MapWithRefs, Ref]);
   });
 });

--- a/packages/react-map-explorer/src/mapLoader.ts
+++ b/packages/react-map-explorer/src/mapLoader.ts
@@ -70,9 +70,17 @@ export class StoreMapLoader implements IMapLoader {
     const refs: Segment[] = [];
     for (const mapSegment of results) {
       for (const ref of mapSegment.link().refs()) {
-        const refSegment = await this.store.getSegment(
-          hashToString(ref.linkHash)
-        );
+        const refHash = hashToString(ref.linkHash);
+
+        // If we already loaded that reference, continue.
+        if (
+          refs.some(r => hashToString(r.linkHash()) === refHash) ||
+          results.some(s => hashToString(s.linkHash()) === refHash)
+        ) {
+          continue;
+        }
+
+        const refSegment = await this.store.getSegment(refHash);
         if (refSegment) {
           refs.push(refSegment);
         }

--- a/packages/react-map-explorer/test/fixtures/maps.ts
+++ b/packages/react-map-explorer/test/fixtures/maps.ts
@@ -41,6 +41,12 @@ const s3 = new LinkBuilder(TestProcess, TestMapId)
   .build()
   .segmentify();
 
-const MapWithRefs = [s1, s2, s3];
+const s4 = new LinkBuilder(TestProcess, TestMapId)
+  .withParent(s2.linkHash())
+  .withRefs([new LinkReference(Ref.linkHash(), RefProcess)])
+  .build()
+  .segmentify();
+
+const MapWithRefs = [s1, s2, s3, s4];
 
 export { MapWithoutRefs, MapWithRefs, Ref, TestMapId, TestProcess };


### PR DESCRIPTION
When segments reference another segment in the same map, we can't use a tree hierarchy anymore because we need the segment to have multiple parents.
I experimented with dagre-d3 and d3-dag to get a DAG layout, but none of those worked (they ended up throwing exceptions about missing fields, and apparently many people have opened issues that were never resolved).
So instead I decided to keep a tree hierarchy and display additional connections for internal references (until hopefully we find a better DAG layout library). Here is the (ugly) result (steve will work on making it beautiful before we release developer.stratumn.com):

![map-explorer-internal-ref](https://user-images.githubusercontent.com/31281497/48834790-e943d880-ed7e-11e8-9109-5a34f3a89c9a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-core/41)
<!-- Reviewable:end -->
