### PR TITLE
store-client: add method to create a link batch

### DIFF
--- a/packages/store-client/package.json
+++ b/packages/store-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stratumn/store-client",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A client to interact with a Chainscript Store.",
   "keywords": [
     "stratumn",

--- a/packages/store-client/src/client.ts
+++ b/packages/store-client/src/client.ts
@@ -38,6 +38,14 @@ export interface IStoreClient {
   createLink(link: Link): Promise<Segment>;
 
   /**
+   * Create a collection of links atomically in the Chainscript store.
+   * Will throw an error if any of the links could not be created.
+   * @param links links that should be stored.
+   * @returns the segments encapsulating the input links.
+   */
+  createLinkBatch(links: Link[]): Promise<Segment[]>;
+
+  /**
    * Get a segment from its link hash.
    * @param linkHash hex-encoded link hash.
    * @returns the segment with its evidences (if any).

--- a/packages/store-client/src/httpClient.ts
+++ b/packages/store-client/src/httpClient.ts
@@ -163,9 +163,7 @@ export class StoreHttpClient implements IStoreClient {
     this.handleHttpErr(response);
 
     try {
-      const segments = response.data.map((segment: any) =>
-        fromSegmentObject(segment)
-      );
+      const segments = response.data.map(fromSegmentObject);
       return segments;
     } catch (err) {
       throw new Error(

--- a/packages/store-client/src/httpClient.ts
+++ b/packages/store-client/src/httpClient.ts
@@ -154,6 +154,26 @@ export class StoreHttpClient implements IStoreClient {
     return segment;
   }
 
+  public async createLinkBatch(links: Link[]): Promise<Segment[]> {
+    const response = await axios.post(
+      this.storeUrl + '/batch/links',
+      links.map(link => link.toObject({ bytes: String })),
+      this.reqConfig
+    );
+    this.handleHttpErr(response);
+
+    try {
+      const segments = response.data.map((segment: any) =>
+        fromSegmentObject(segment)
+      );
+      return segments;
+    } catch (err) {
+      throw new Error(
+        `expected a segments list, received: ${JSON.stringify(response.data)}`
+      );
+    }
+  }
+
   public async getSegment(linkHash: string): Promise<Segment | null> {
     const response = await axios.get(
       this.storeUrl + '/segments/' + linkHash,


### PR DESCRIPTION
The client can now call the new batch link creation API.
Last step needed is to integrate in Trace ;).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-core/46)
<!-- Reviewable:end -->
